### PR TITLE
Add a python gaudi config

### DIFF
--- a/share/example.py
+++ b/share/example.py
@@ -1,0 +1,46 @@
+from Gaudi.Configuration import *
+
+from Configurables import LcioEvent, EventDataSvc, MarlinProcessorWrapper
+from k4MarlinWrapper.parseConstants import *
+algList = []
+evtsvc = EventDataSvc()
+
+
+CONSTANTS = {
+}
+
+parseConstants(CONSTANTS)
+
+read = LcioEvent()
+read.OutputLevel = WARNING
+read.Files = ["input_file.slcio"]
+algList.append(read)
+
+MyAIDAProcessor = MarlinProcessorWrapper("MyAIDAProcessor")
+MyAIDAProcessor.OutputLevel = WARNING 
+MyAIDAProcessor.ProcessorType = "AIDAProcessor" 
+MyAIDAProcessor.Parameters = {
+                              "Compress": ["1"],
+                              "FileName": ["histograms"],
+                              "FileType": ["root"]
+                              }
+
+MyProcessor = MarlinProcessorWrapper("MyProcessor")
+MyProcessor.OutputLevel = WARNING 
+MyProcessor.ProcessorType = "TemplateProcessor" 
+MyProcessor.Parameters = {
+                          "InputCollectionName": ["MCParticle"],
+                          "MinPt": ["2"],
+                          "OutputCollectionName": ["OutMCParticle"]
+                          }
+
+algList.append(MyAIDAProcessor)
+algList.append(MyProcessor)
+
+from Configurables import ApplicationMgr
+ApplicationMgr( TopAlg = algList,
+                EvtSel = 'NONE',
+                EvtMax   = 10,
+                ExtSvc = [evtsvc],
+                OutputLevel=WARNING
+              )


### PR DESCRIPTION
Hi @kkrizka . I made a gaudi-style python config:

```
# cf: https://key4hep.github.io/key4hep-doc/how-tos/k4marlinwrapper/doc/MarlinWrapperIntroduction.html
convertMarlinSteeringToGaudi.py TemplatePackage/share/example.xml TemplatePackage/share/example.py
```

How does that look to you? 

It runs like:

```
k4run TemplatePackage/share/example.py --LcioEvent.Files output_reco.slcio 2>&1 | tee log.txt
```

I actually see a FATAL message when running the processor. But there's seems to be no impact, since the terminal messages appear normal and the ROOT file + histogram is created normally.

Log file: 
[TemplatePackage_share_example.py.txt](https://github.com/user-attachments/files/16397336/TemplatePackage_share_example.py.txt)
